### PR TITLE
feat: replace with dynamic vars

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -8,3 +8,9 @@ testData:
   rewrites:
     - regex: "bar"
       replacement: "foo"
+    - regex: "foo"
+      replacement: "{.Host}"
+    - regex: "bar"
+      replacement: "/.Host/"
+      delimiterLeft: "/"
+      delimiterRight: "/"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ by replacing a search regex by a replacement string.
 
 To configure the `Rewrite Body` plugin you should create a [middleware](https://docs.traefik.io/middlewares/overview/) in 
 your dynamic configuration as explained [here](https://docs.traefik.io/middlewares/overview/). The following example creates
-and uses the `rewritebody` middleware plugin to replace all foo occurences by bar in the HTTP response body.
+and uses the `rewritebody` middleware plugin to replace all foo occurences by bar in the HTTP response body.`
+
+You can replace with variables from the `http.Request` variable. For example to get the `req.Host` variable use `{.Host}` in your
+replacement string. You can change the delimiter to use something different that the brackets. See examples for more information.
 
 If you want to apply some limits on the response body, you can chain this middleware plugin with the [Buffering middleware](https://docs.traefik.io/middlewares/buffering/) from Traefik.
 
@@ -41,6 +44,18 @@ If you want to apply some limits on the response body, you can chain this middle
     [[http.middlewares.rewrite-foo.plugin.rewritebody.rewrites]]
       regex = "foo"
       replacement = "bar"
+
+    # Rewrites all "bar" occurences by the host requested
+    [[http.middlewares.rewrite-foo.plugin.rewritebody.rewrites]]
+      regex = "bar"
+      replacement = "{.Host}"
+    
+    # Rewrites all "example.com" occurences by the Method requested and by changing the delimiters
+    [[http.middlewares.rewrite-foo.plugin.rewritebody.rewrites]]
+      regex = "example.com"
+      replacement = "/.Method/"
+      delimiterLeft = "/"
+      delimiterRight = "/"      
 
 [http.services]
   [http.services.my-service]

--- a/rewritebody_test.go
+++ b/rewritebody_test.go
@@ -84,6 +84,65 @@ func TestServeHTTP(t *testing.T) {
 			expResBody:      "bar is the new bar",
 			expLastModified: true,
 		},
+		{
+			desc: "should replace foo by the req.Host var",
+			rewrites: []Rewrite{
+				{
+					Regex:       "foo",
+					Replacement: "{.Host}",
+				},
+			},
+			resBody:    "foo is the new bar",
+			expResBody: "example.com is the new bar",
+		},
+		{
+			desc: "should replace foo by the req.Proto/req.Method vars",
+			rewrites: []Rewrite{
+				{
+					Regex:       "foo",
+					Replacement: "{.ContentLength} {.Method}",
+				},
+			},
+			resBody:    "foo is the new bar",
+			expResBody: "0 GET is the new bar",
+		},
+		{
+			desc: "should replace foo by {}",
+			rewrites: []Rewrite{
+				{
+					Regex:          "foo",
+					Replacement:    "{}",
+					DelimiterLeft:  "/",
+					DelimiterRight: "/",
+				},
+			},
+			resBody:    "foo is the new bar",
+			expResBody: "{} is the new bar",
+		},
+		{
+			desc: "should replace foo by Host with delimiters /",
+			rewrites: []Rewrite{
+				{
+					Regex:          "foo",
+					Replacement:    "/.Host/",
+					DelimiterLeft:  "/",
+					DelimiterRight: "/",
+				},
+			},
+			resBody:    "foo is {the} new bar",
+			expResBody: "example.com is {the} new bar",
+		},
+		{
+			desc: "Replacement with unavailable var should return nothing",
+			rewrites: []Rewrite{
+				{
+					Regex:       "foo",
+					Replacement: "{.Toto}",
+				},
+			},
+			resBody:    "foo is the new bar",
+			expResBody: "",
+		},
 	}
 
 	for _, test := range tests {
@@ -139,6 +198,22 @@ func TestNew(t *testing.T) {
 				{
 					Regex:       "foo",
 					Replacement: "bar",
+				},
+				{
+					Regex:       "bar",
+					Replacement: "foo",
+				},
+			},
+			expErr: false,
+		},
+		{
+			desc: "should return no error when adding delimiters",
+			rewrites: []Rewrite{
+				{
+					Regex:          "foo",
+					Replacement:    "bar",
+					DelimiterLeft:  "/",
+					DelimiterRight: "/",
 				},
 				{
 					Regex:       "bar",


### PR DESCRIPTION
Fixes #5 

Allows replacement with variables from http.Request var.
Not using `{{ }}` as default delimiter because the file provider is trying to interpret the replacements as golang template directly.